### PR TITLE
Add README.md with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Deprecation Notice
+
+**The [EventBus](https://github.com/LaxarJS/laxar/tree/master/lib/runtime/event_bus.js) is now fully integrated into [LaxarJS](https://github.com/LaxarJS/laxar).**
+If you are interested in a standalone version, please let us know! (For example, by [filing an issue](https://github.com/LaxarJS/laxar/issues/new) in the LaxarJS project.)
+
+For details on _what this thing is_ and how it is used, please refer to the [documentation](https://github.com/LaxarJS/laxar/blob/master/docs/manuals/events.md#the-event-bus) in LaxarJS.


### PR DESCRIPTION
@mkemmann, just a little housekeeping.

I added a [README](https://github.com/aixigo/event_bus/blob/aa89af0/README.md), mentioning where to find the latest version of the EventBus and encouraging people who are interested in a standalone version to request it in LaxarJS.